### PR TITLE
Extract token string from multiple headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,31 @@ func newClaimsHandler() fiber.Handler {
 }
 ```
 
+## Other options
+
+### Extract token from multiple headers
+
+Example for `Authorization` and `Sec-WebSocket-Protocol`. If token is found in `Authorization`, `Sec-WebSocket-Protocol` will not be tried.
+
+```go
+oidcHandler := oidcgin.New(
+	options.WithIssuer(cfg.Issuer),
+	options.WithFallbackSignatureAlgorithm(cfg.FallbackSignatureAlgorithm),
+	options.WithRequiredClaims(map[string]interface{}{
+		"cid": cfg.ClientID,
+	}),
+	options.WithTokenString(
+		options.WithTokenStringHeaderName("Authorization"),
+		options.WithTokenStringTokenPrefix("Bearer "),
+	),
+	options.WithTokenString(
+		options.WithTokenStringHeaderName("Sec-WebSocket-Protocol"),
+		options.WithTokenStringTokenPrefix("base64url.bearer.authorization.k8s.io."),
+		options.WithTokenStringListSeparator(","),
+	),
+)
+```
+
 ## Examples
 
 See [examples readme](examples/README.md) for more information.

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -436,8 +436,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55 h1:rw6UNGRMfarCepjI8qOepea/SXwIBVfTKjztZ5gBbq4=
-golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	golang.org/x/mod v0.5.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55 // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
 	golang.org/x/tools v0.1.5 // indirect
 	honnef.co/go/tools v0.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -452,8 +452,8 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55 h1:rw6UNGRMfarCepjI8qOepea/SXwIBVfTKjztZ5gBbq4=
-golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/oidc/tokenstring.go
+++ b/internal/oidc/tokenstring.go
@@ -11,7 +11,7 @@ type GetHeaderFn func(key string) string
 
 const maxListSeparatorSlices = 20
 
-// GetTokenString extracts a token string
+// GetTokenString extracts a token string.
 func GetTokenString(getHeaderFn GetHeaderFn, tokenStringOpts [][]options.TokenStringOption) (string, error) {
 	opts := tokenStringOpts
 	if len(opts) == 0 {

--- a/internal/oidctesting/tests.go
+++ b/internal/oidctesting/tests.go
@@ -131,8 +131,7 @@ func runTestHandler(t *testing.T, testName string, tester tester) {
 			options.WithRequiredTokenType("JWT+AT"),
 			options.WithTokenString(
 				options.WithTokenStringHeaderName("Authorization"),
-				options.WithTokenStringDelimiter(" "),
-				options.WithTokenStringTokenType("Bearer"),
+				options.WithTokenStringTokenPrefix("Bearer "),
 			),
 		)
 

--- a/oidcfiber/fiber.go
+++ b/oidcfiber/fiber.go
@@ -21,14 +21,15 @@ func New(setters ...options.Option) fiber.Handler {
 
 func toFiberHandler(parseToken oidc.ParseTokenFunc, setters ...options.Option) fiber.Handler {
 	opts := options.New(setters...)
-	tokenStringOpts := options.NewTokenString(opts.TokenString...)
 
 	return func(c *fiber.Ctx) error {
 		ctx := c.Context()
 
-		authz := c.Get(tokenStringOpts.HeaderName)
+		getHeaderFn := func(key string) string {
+			return c.Get(key)
+		}
 
-		tokenString, err := oidc.GetTokenStringFromString(authz, opts.TokenString...)
+		tokenString, err := oidc.GetTokenString(getHeaderFn, opts.TokenString)
 		if err != nil {
 			return c.SendStatus(fiber.StatusBadRequest)
 		}

--- a/oidcgin/gin.go
+++ b/oidcgin/gin.go
@@ -26,7 +26,7 @@ func toGinHandler(parseToken oidc.ParseTokenFunc, setters ...options.Option) gin
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
-		tokenString, err := oidc.GetTokenStringFromRequest(c.Request, opts.TokenString...)
+		tokenString, err := oidc.GetTokenString(c.Request.Header.Get, opts.TokenString)
 		if err != nil {
 			c.AbortWithStatus(http.StatusBadRequest)
 			return

--- a/oidchttp/http.go
+++ b/oidchttp/http.go
@@ -26,7 +26,7 @@ func toHttpHandler(h http.Handler, parseToken oidc.ParseTokenFunc, setters ...op
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		tokenString, err := oidc.GetTokenStringFromRequest(r, opts.TokenString...)
+		tokenString, err := oidc.GetTokenString(r.Header.Get, opts.TokenString)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return

--- a/options/options.go
+++ b/options/options.go
@@ -104,7 +104,7 @@ type Options struct {
 	// TokenString makes it possible to configure how the JWT token should be extracted from
 	// an http header. Not supported by Echo JWT and will be ignored if used by it.
 	// Defaults to: 'Authorization: Bearer JWT'
-	TokenString []TokenStringOption
+	TokenString [][]TokenStringOption
 
 	// ClaimsContextKeyName is the name of key that will be used to pass claims using request context.
 	// Not supported by Echo JWT and will be ignored if used by it.
@@ -233,8 +233,11 @@ func WithHttpClient(opt *http.Client) Option {
 
 // WithTokenString sets the TokenString parameter for an Options pointer.
 func WithTokenString(setters ...TokenStringOption) Option {
+	var tokenString []TokenStringOption
+	tokenString = append(tokenString, setters...)
+
 	return func(opts *Options) {
-		opts.TokenString = append(opts.TokenString, setters...)
+		opts.TokenString = append(opts.TokenString, tokenString)
 	}
 }
 

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -32,9 +32,9 @@ func TestOptions(t *testing.T) {
 	}
 
 	expectedTokenString := &TokenStringOptions{
-		HeaderName: "foo",
-		Delimiter:  "_",
-		TokenType:  "bar",
+		HeaderName:    "foo",
+		TokenPrefix:   "bar_",
+		ListSeparator: ",",
 	}
 
 	setters := []Option{
@@ -57,8 +57,8 @@ func TestOptions(t *testing.T) {
 		}),
 		WithTokenString(
 			WithTokenStringHeaderName("foo"),
-			WithTokenStringDelimiter("_"),
-			WithTokenStringTokenType("bar"),
+			WithTokenStringTokenPrefix("bar_"),
+			WithTokenStringListSeparator(","),
 		),
 		WithClaimsContextKeyName("foo"),
 	}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -71,7 +71,7 @@ func TestOptions(t *testing.T) {
 
 	resultTokenString := &TokenStringOptions{}
 
-	for _, setter := range result.TokenString {
+	for _, setter := range result.TokenString[0] {
 		setter(resultTokenString)
 	}
 

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -31,10 +31,16 @@ func TestOptions(t *testing.T) {
 		ClaimsContextKeyName: ClaimsContextKeyName("foo"),
 	}
 
-	expectedTokenString := &TokenStringOptions{
+	expectedFirstTokenString := &TokenStringOptions{
 		HeaderName:    "foo",
 		TokenPrefix:   "bar_",
 		ListSeparator: ",",
+	}
+
+	expectedSecondTokenString := &TokenStringOptions{
+		HeaderName:    "too",
+		TokenPrefix:   "lar_",
+		ListSeparator: "",
 	}
 
 	setters := []Option{
@@ -60,6 +66,10 @@ func TestOptions(t *testing.T) {
 			WithTokenStringTokenPrefix("bar_"),
 			WithTokenStringListSeparator(","),
 		),
+		WithTokenString(
+			WithTokenStringHeaderName("too"),
+			WithTokenStringTokenPrefix("lar_"),
+		),
 		WithClaimsContextKeyName("foo"),
 	}
 
@@ -69,15 +79,21 @@ func TestOptions(t *testing.T) {
 		setter(result)
 	}
 
-	resultTokenString := &TokenStringOptions{}
+	resultFirstTokenString := &TokenStringOptions{}
+	resultSecondTokenString := &TokenStringOptions{}
 
 	for _, setter := range result.TokenString[0] {
-		setter(resultTokenString)
+		setter(resultFirstTokenString)
+	}
+
+	for _, setter := range result.TokenString[1] {
+		setter(resultSecondTokenString)
 	}
 
 	// Needed or else expectedResult can't be compared to result
 	result.TokenString = nil
 
 	require.Equal(t, expectedResult, result)
-	require.Equal(t, expectedTokenString, resultTokenString)
+	require.Equal(t, expectedFirstTokenString, resultFirstTokenString)
+	require.Equal(t, expectedSecondTokenString, resultSecondTokenString)
 }

--- a/options/tokenstring.go
+++ b/options/tokenstring.go
@@ -6,6 +6,11 @@ type TokenStringOptions struct {
 	// Default: "Authorization"
 	HeaderName string
 
+	// HeaderValueSeparator defines if the header value is separated into an array and if so what the separator is
+	// Default: ""
+	// Example could be: `HeaderName = foo,Bearer token,bar` and in that case HeaderValueSeparator should be set to "," (comma)
+	HeaderValueSeparator string
+
 	// Delimiter is the delimiter between the token type and the token.
 	// Default: " " (single space)
 	Delimiter string
@@ -17,9 +22,10 @@ type TokenStringOptions struct {
 
 func NewTokenString(setters ...TokenStringOption) *TokenStringOptions {
 	opts := &TokenStringOptions{
-		HeaderName: "Authorization",
-		Delimiter:  " ",
-		TokenType:  "Bearer",
+		HeaderName:           "Authorization",
+		HeaderValueSeparator: "",
+		Delimiter:            " ",
+		TokenType:            "Bearer",
 	}
 
 	for _, setter := range setters {
@@ -36,6 +42,13 @@ type TokenStringOption func(*TokenStringOptions)
 func WithTokenStringHeaderName(opt string) TokenStringOption {
 	return func(opts *TokenStringOptions) {
 		opts.HeaderName = opt
+	}
+}
+
+// WithHeaderValueSeparator sets the HeaderValueSeparator parameter for a TokenStringOptions pointer.
+func WithHeaderValueSeparator(opt string) TokenStringOption {
+	return func(opts *TokenStringOptions) {
+		opts.HeaderValueSeparator = opt
 	}
 }
 

--- a/options/tokenstring.go
+++ b/options/tokenstring.go
@@ -6,26 +6,22 @@ type TokenStringOptions struct {
 	// Default: "Authorization"
 	HeaderName string
 
-	// HeaderValueSeparator defines if the header value is separated into an array and if so what the separator is
-	// Default: ""
-	// Example could be: `HeaderName = foo,Bearer token,bar` and in that case HeaderValueSeparator should be set to "," (comma)
-	HeaderValueSeparator string
+	// TokenPrefix defines the prefix that should be trimmed from the header value
+	// to extract the token.
+	// Default: "Bearer "
+	TokenPrefix string
 
-	// Delimiter is the delimiter between the token type and the token.
-	// Default: " " (single space)
-	Delimiter string
-
-	// TokenType is the type of token that is sent.
-	// Default: "Bearer"
-	TokenType string
+	// ListSeparator defines if the value of the header is a list or not.
+	// The value will be split (up to 20 slices) by the ListSeparator.
+	// Default disabled: ""
+	ListSeparator string
 }
 
 func NewTokenString(setters ...TokenStringOption) *TokenStringOptions {
 	opts := &TokenStringOptions{
-		HeaderName:           "Authorization",
-		HeaderValueSeparator: "",
-		Delimiter:            " ",
-		TokenType:            "Bearer",
+		HeaderName:    "Authorization",
+		TokenPrefix:   "Bearer ",
+		ListSeparator: "",
 	}
 
 	for _, setter := range setters {
@@ -45,23 +41,16 @@ func WithTokenStringHeaderName(opt string) TokenStringOption {
 	}
 }
 
-// WithHeaderValueSeparator sets the HeaderValueSeparator parameter for a TokenStringOptions pointer.
-func WithHeaderValueSeparator(opt string) TokenStringOption {
+// WithTokenStringTokenPrefix sets the TokenPrefix parameter for a TokenStringOptions pointer.
+func WithTokenStringTokenPrefix(opt string) TokenStringOption {
 	return func(opts *TokenStringOptions) {
-		opts.HeaderValueSeparator = opt
+		opts.TokenPrefix = opt
 	}
 }
 
-// WithTokenStringDelimiter sets the Delimiter parameter for a TokenStringOptions pointer.
-func WithTokenStringDelimiter(opt string) TokenStringOption {
+// WithTokenStringListSeparator sets the ListSeparator parameter for a TokenStringOptions pointer.
+func WithTokenStringListSeparator(opt string) TokenStringOption {
 	return func(opts *TokenStringOptions) {
-		opts.Delimiter = opt
-	}
-}
-
-// WithTokenStringTokenType sets the TokenType for a TokenStringOptions pointer.
-func WithTokenStringTokenType(opt string) TokenStringOption {
-	return func(opts *TokenStringOptions) {
-		opts.TokenType = opt
+		opts.ListSeparator = opt
 	}
 }


### PR DESCRIPTION
This PR adds the ability to extract tokens from multiple headers.

Example:
```go
oidcHandler := oidcgin.New(
	options.WithIssuer(cfg.Issuer),
	options.WithFallbackSignatureAlgorithm(cfg.FallbackSignatureAlgorithm),
	options.WithRequiredClaims(map[string]interface{}{
		"cid": cfg.ClientID,
	}),
	options.WithTokenString(
		options.WithTokenStringHeaderName("Authorization"),
		options.WithTokenStringTokenPrefix("Bearer "),
	),
	options.WithTokenString(
		options.WithTokenStringHeaderName("Sec-WebSocket-Protocol"),
		options.WithTokenStringTokenPrefix("base64url.bearer.authorization.k8s.io."),
		options.WithTokenStringListSeparator(","),
	),
)
```

In the above case, if a token string is found in `Authorization` it will be used - if not `Sec-WebSocket-Protocol` will be tested.

Closes #45 