### PR TITLE
Make discovery fetch timeout configurable

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -11,11 +11,11 @@ replace (
 )
 
 require (
-	github.com/xenitab/go-oidc-middleware v0.0.25
-	github.com/xenitab/go-oidc-middleware/oidcechojwt v0.0.24
-	github.com/xenitab/go-oidc-middleware/oidcfiber v0.0.24
-	github.com/xenitab/go-oidc-middleware/oidcgin v0.0.24
-	github.com/xenitab/go-oidc-middleware/oidchttp v0.0.24
+	github.com/xenitab/go-oidc-middleware v0.0.26
+	github.com/xenitab/go-oidc-middleware/oidcechojwt v0.0.26
+	github.com/xenitab/go-oidc-middleware/oidcfiber v0.0.26
+	github.com/xenitab/go-oidc-middleware/oidcgin v0.0.26
+	github.com/xenitab/go-oidc-middleware/oidchttp v0.0.26
 )
 
 require (

--- a/internal/coverage/go.mod
+++ b/internal/coverage/go.mod
@@ -11,11 +11,11 @@ replace (
 )
 
 require (
-	github.com/xenitab/go-oidc-middleware v0.0.25
-	github.com/xenitab/go-oidc-middleware/oidcechojwt v0.0.24
-	github.com/xenitab/go-oidc-middleware/oidcfiber v0.0.24
-	github.com/xenitab/go-oidc-middleware/oidcgin v0.0.24
-	github.com/xenitab/go-oidc-middleware/oidchttp v0.0.24
+	github.com/xenitab/go-oidc-middleware v0.0.26
+	github.com/xenitab/go-oidc-middleware/oidcechojwt v0.0.26
+	github.com/xenitab/go-oidc-middleware/oidcfiber v0.0.26
+	github.com/xenitab/go-oidc-middleware/oidcgin v0.0.26
+	github.com/xenitab/go-oidc-middleware/oidchttp v0.0.26
 )
 
 require (

--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -25,6 +25,7 @@ var (
 type handler struct {
 	issuer                     string
 	discoveryUri               string
+	discoveryFetchTimeout      time.Duration
 	jwksUri                    string
 	jwksFetchTimeout           time.Duration
 	jwksRateLimit              uint
@@ -43,17 +44,18 @@ func NewHandler(setters ...options.Option) (*handler, error) {
 	opts := options.New(setters...)
 
 	h := &handler{
-		issuer:            opts.Issuer,
-		discoveryUri:      opts.DiscoveryUri,
-		jwksUri:           opts.JwksUri,
-		jwksFetchTimeout:  opts.JwksFetchTimeout,
-		jwksRateLimit:     opts.JwksRateLimit,
-		allowedTokenDrift: opts.AllowedTokenDrift,
-		requiredTokenType: opts.RequiredTokenType,
-		requiredAudience:  opts.RequiredAudience,
-		requiredClaims:    opts.RequiredClaims,
-		disableKeyID:      opts.DisableKeyID,
-		httpClient:        opts.HttpClient,
+		issuer:                opts.Issuer,
+		discoveryUri:          opts.DiscoveryUri,
+		discoveryFetchTimeout: opts.DiscoveryFetchTimeout,
+		jwksUri:               opts.JwksUri,
+		jwksFetchTimeout:      opts.JwksFetchTimeout,
+		jwksRateLimit:         opts.JwksRateLimit,
+		allowedTokenDrift:     opts.AllowedTokenDrift,
+		requiredTokenType:     opts.RequiredTokenType,
+		requiredAudience:      opts.RequiredAudience,
+		requiredClaims:        opts.RequiredClaims,
+		disableKeyID:          opts.DisableKeyID,
+		httpClient:            opts.HttpClient,
 	}
 
 	if h.issuer == "" {
@@ -82,7 +84,7 @@ func NewHandler(setters ...options.Option) (*handler, error) {
 
 func (h *handler) loadJwks() error {
 	if h.jwksUri == "" {
-		jwksUri, err := getJwksUriFromDiscoveryUri(h.httpClient, h.discoveryUri, 5*time.Second)
+		jwksUri, err := getJwksUriFromDiscoveryUri(h.httpClient, h.discoveryUri, h.discoveryFetchTimeout)
 		if err != nil {
 			return fmt.Errorf("unable to fetch jwksUri from discoveryUri (%s): %w", h.discoveryUri, err)
 		}

--- a/oidcechojwt/go.mod
+++ b/oidcechojwt/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 replace github.com/xenitab/go-oidc-middleware => ../
 
-require github.com/xenitab/go-oidc-middleware v0.0.25
+require github.com/xenitab/go-oidc-middleware v0.0.26
 
 require (
 	github.com/labstack/echo/v4 v4.7.2

--- a/oidcfiber/go.mod
+++ b/oidcfiber/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 replace github.com/xenitab/go-oidc-middleware => ../
 
-require github.com/xenitab/go-oidc-middleware v0.0.25
+require github.com/xenitab/go-oidc-middleware v0.0.26
 
 require (
 	github.com/gofiber/fiber/v2 v2.31.0

--- a/oidcgin/go.mod
+++ b/oidcgin/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 replace github.com/xenitab/go-oidc-middleware => ../
 
-require github.com/xenitab/go-oidc-middleware v0.0.25
+require github.com/xenitab/go-oidc-middleware v0.0.26
 
 require github.com/gin-gonic/gin v1.7.7
 

--- a/oidchttp/go.mod
+++ b/oidchttp/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 replace github.com/xenitab/go-oidc-middleware => ../
 
-require github.com/xenitab/go-oidc-middleware v0.0.25
+require github.com/xenitab/go-oidc-middleware v0.0.26
 
 require (
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect

--- a/options/options.go
+++ b/options/options.go
@@ -31,6 +31,7 @@ const (
 type Options struct {
 	Issuer                     string
 	DiscoveryUri               string
+	DiscoveryFetchTimeout      time.Duration
 	JwksUri                    string
 	JwksFetchTimeout           time.Duration
 	JwksRateLimit              uint
@@ -52,11 +53,12 @@ type Options struct {
 // needed by any external application using this library.
 func New(setters ...Option) *Options {
 	opts := &Options{
-		JwksFetchTimeout:     5 * time.Second,
-		JwksRateLimit:        1,
-		AllowedTokenDrift:    10 * time.Second,
-		HttpClient:           http.DefaultClient,
-		ClaimsContextKeyName: DefaultClaimsContextKeyName,
+		DiscoveryFetchTimeout: 5 * time.Second,
+		JwksFetchTimeout:      5 * time.Second,
+		JwksRateLimit:         1,
+		AllowedTokenDrift:     10 * time.Second,
+		HttpClient:            http.DefaultClient,
+		ClaimsContextKeyName:  DefaultClaimsContextKeyName,
 	}
 
 	for _, setter := range setters {
@@ -83,6 +85,15 @@ func WithIssuer(opt string) Option {
 func WithDiscoveryUri(opt string) Option {
 	return func(opts *Options) {
 		opts.DiscoveryUri = opt
+	}
+}
+
+// WithDiscoveryFetchTimeout sets the DiscoveryFetchTimeout parameter for an Options pointer.
+// DiscoveryFetchTimeout sets the context timeout when downloading the discovery metadata
+// Defaults to 5 seconds
+func WithDiscoveryFetchTimeout(opt time.Duration) Option {
+	return func(opts *Options) {
+		opts.DiscoveryFetchTimeout = opt
 	}
 }
 

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -12,6 +12,7 @@ func TestOptions(t *testing.T) {
 	expectedResult := &Options{
 		Issuer:                     "foo",
 		DiscoveryUri:               "foo",
+		DiscoveryFetchTimeout:      1234 * time.Second,
 		JwksUri:                    "foo",
 		JwksFetchTimeout:           1234 * time.Second,
 		JwksRateLimit:              1234,
@@ -47,6 +48,7 @@ func TestOptions(t *testing.T) {
 	setters := []Option{
 		WithIssuer("foo"),
 		WithDiscoveryUri("foo"),
+		WithDiscoveryFetchTimeout(1234 * time.Second),
 		WithJwksUri("foo"),
 		WithJwksFetchTimeout(1234 * time.Second),
 		WithJwksRateLimit(1234),


### PR DESCRIPTION
The timeout to download the discovery metadata was hard coded to be 5 seconds. This change makes it configurable through the `WithDiscoveryFetchTimeout()` option. Still defaults to 5 seconds.

Fixes #148 