### PR TITLE
Add support for opaque access tokens in optest

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ func TestFoobar(t *testing.T) {
 }
 ```
 
+It is also possible to enable opaque access tokens with the option `optest.WithOpaqueAccessTokens()`.
+
 ## Examples
 
 See [examples readme](examples/README.md) for more information.

--- a/oidcechojwt/go.sum
+++ b/oidcechojwt/go.sum
@@ -81,8 +81,8 @@ github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xenitab/dispans v0.0.10 h1:S+gSUM14rDJWK7MYNrjb8JbjeQPip6mlNJyLX+g7Agc=
-github.com/xenitab/go-oidc-middleware v0.0.29 h1:iCbTIVJXeuuX9jYU3kr7VZQeGGeXz10FcFMo9IejA1E=
-github.com/xenitab/go-oidc-middleware v0.0.29/go.mod h1:jstNDKrVIR2QLgbtD6FC9yKTd5/ACkvwiXtLAGaNEWw=
+github.com/xenitab/go-oidc-middleware v0.0.30 h1:K5H+xuH+L+uGs/j1u4fxMPiHYd5oalxeffAyjKjQvRw=
+github.com/xenitab/go-oidc-middleware v0.0.30/go.mod h1:jstNDKrVIR2QLgbtD6FC9yKTd5/ACkvwiXtLAGaNEWw=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=

--- a/oidcfiber/go.sum
+++ b/oidcfiber/go.sum
@@ -81,8 +81,8 @@ github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7Fw
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xenitab/dispans v0.0.10 h1:S+gSUM14rDJWK7MYNrjb8JbjeQPip6mlNJyLX+g7Agc=
-github.com/xenitab/go-oidc-middleware v0.0.29 h1:iCbTIVJXeuuX9jYU3kr7VZQeGGeXz10FcFMo9IejA1E=
-github.com/xenitab/go-oidc-middleware v0.0.29/go.mod h1:jstNDKrVIR2QLgbtD6FC9yKTd5/ACkvwiXtLAGaNEWw=
+github.com/xenitab/go-oidc-middleware v0.0.30 h1:K5H+xuH+L+uGs/j1u4fxMPiHYd5oalxeffAyjKjQvRw=
+github.com/xenitab/go-oidc-middleware v0.0.30/go.mod h1:jstNDKrVIR2QLgbtD6FC9yKTd5/ACkvwiXtLAGaNEWw=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=

--- a/oidcgin/go.sum
+++ b/oidcgin/go.sum
@@ -110,8 +110,8 @@ github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xenitab/dispans v0.0.10 h1:S+gSUM14rDJWK7MYNrjb8JbjeQPip6mlNJyLX+g7Agc=
-github.com/xenitab/go-oidc-middleware v0.0.29 h1:iCbTIVJXeuuX9jYU3kr7VZQeGGeXz10FcFMo9IejA1E=
-github.com/xenitab/go-oidc-middleware v0.0.29/go.mod h1:jstNDKrVIR2QLgbtD6FC9yKTd5/ACkvwiXtLAGaNEWw=
+github.com/xenitab/go-oidc-middleware v0.0.30 h1:K5H+xuH+L+uGs/j1u4fxMPiHYd5oalxeffAyjKjQvRw=
+github.com/xenitab/go-oidc-middleware v0.0.30/go.mod h1:jstNDKrVIR2QLgbtD6FC9yKTd5/ACkvwiXtLAGaNEWw=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=

--- a/oidchttp/go.sum
+++ b/oidchttp/go.sum
@@ -65,8 +65,8 @@ github.com/tidwall/tinyqueue v0.1.1 h1:SpNEvEggbpyN5DIReaJ2/1ndroY8iyEGxPYxoSaym
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xenitab/dispans v0.0.10 h1:S+gSUM14rDJWK7MYNrjb8JbjeQPip6mlNJyLX+g7Agc=
-github.com/xenitab/go-oidc-middleware v0.0.29 h1:iCbTIVJXeuuX9jYU3kr7VZQeGGeXz10FcFMo9IejA1E=
-github.com/xenitab/go-oidc-middleware v0.0.29/go.mod h1:jstNDKrVIR2QLgbtD6FC9yKTd5/ACkvwiXtLAGaNEWw=
+github.com/xenitab/go-oidc-middleware v0.0.30 h1:K5H+xuH+L+uGs/j1u4fxMPiHYd5oalxeffAyjKjQvRw=
+github.com/xenitab/go-oidc-middleware v0.0.30/go.mod h1:jstNDKrVIR2QLgbtD6FC9yKTd5/ACkvwiXtLAGaNEWw=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=

--- a/optest/opaque_access_token.go
+++ b/optest/opaque_access_token.go
@@ -1,0 +1,48 @@
+package optest
+
+import (
+	"sync"
+	"time"
+)
+
+type opaqueAccesToken struct {
+	jwtAccessToken string
+	expires        time.Time
+}
+
+type opaqueAccessTokenContainer struct {
+	values map[string]opaqueAccesToken
+	mu     sync.RWMutex
+}
+
+func newOpaqueAccessTokenContainer() *opaqueAccessTokenContainer {
+	return &opaqueAccessTokenContainer{
+		values: make(map[string]opaqueAccesToken),
+	}
+}
+
+func (c *opaqueAccessTokenContainer) set(opaqueToken string, jwtAccessToken string, expires time.Time) {
+	c.mu.Lock()
+	c.values[opaqueToken] = opaqueAccesToken{
+		jwtAccessToken,
+		expires,
+	}
+	for k := range c.values {
+		if c.values[k].expires.Before(time.Now()) {
+			delete(c.values, k)
+		}
+	}
+	c.mu.Unlock()
+}
+
+func (c *opaqueAccessTokenContainer) get(opaqueToken string) (string, bool) {
+	c.mu.Lock()
+	for k := range c.values {
+		if c.values[k].expires.Before(time.Now()) {
+			delete(c.values, k)
+		}
+	}
+	v, ok := c.values[opaqueToken]
+	c.mu.Unlock()
+	return v.jwtAccessToken, ok
+}

--- a/optest/options.go
+++ b/optest/options.go
@@ -9,7 +9,18 @@ type Options struct {
 	TestUsers       map[string]TestUser
 	TokenExpiration time.Duration
 	AutoStart       bool
+	AccessTokenType AccessTokenType
 }
+
+// AccessTokenType defines the type of token to be used.
+type AccessTokenType int
+
+const (
+	// JwtAccessTokenType sets the access token to be a JWT.
+	JwtAccessTokenType = iota
+	// OpaqueAccessTokenType sets the access token to be opaque.
+	OpaqueAccessTokenType
+)
 
 // Option is used to configure functional options for OPTest.
 type Option func(*Options)
@@ -51,5 +62,13 @@ func WithTokenExpiration(opt time.Duration) Option {
 func WithoutAutoStart() Option {
 	return func(opts *Options) {
 		opts.AutoStart = false
+	}
+}
+
+// WithOpaqueAccessTokens enables opaque access tokens.
+// Default is access tokens as JWT.
+func WithOpaqueAccessTokens() Option {
+	return func(opts *Options) {
+		opts.AccessTokenType = OpaqueAccessTokenType
 	}
 }


### PR DESCRIPTION
This makes it possible to get opaque tokens from optest using the option `optest.WithOpaqueAccessTokens()`.