### PR TITLE
optest: make it possible to show login prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ func TestFoobar(t *testing.T) {
 }
 ```
 
-It is also possible to enable opaque access tokens with the option `optest.WithOpaqueAccessTokens()`.
+It is also possible to enable opaque access tokens with the option `optest.WithOpaqueAccessTokens()`. If you add `optest.WithLoginPrompt()` you will have a simple HTML page with the different test users to choose from when going to `/authorization`.
 
 ## Examples
 

--- a/examples/op/main.go
+++ b/examples/op/main.go
@@ -32,6 +32,23 @@ func main() {
 					"client_id": "pkce-cli",
 				},
 			},
+			"foo": {
+				Audience:           "https://localhost:8081",
+				Subject:            "foo",
+				Name:               "Foo Bar",
+				GivenName:          "Foo",
+				FamilyName:         "Bar",
+				Locale:             "sv-SE",
+				Email:              "asdfs@foo.se",
+				AccessTokenKeyType: "at+jwt",
+				IdTokenKeyType:     "jwt",
+				ExtraIdTokenClaims: map[string]interface{}{
+					"client_id": "pkce-cli",
+				},
+				ExtraAccessTokenClaims: map[string]interface{}{
+					"client_id": "pkce-cli",
+				},
+			},
 		}),
 	)
 	if err != nil {
@@ -46,6 +63,7 @@ func main() {
 	r.Any("/authorization", gin.WrapH(opRouter))
 	r.Any("/token", gin.WrapH(opRouter))
 	r.Any("/jwks", gin.WrapH(opRouter))
+	r.Any("/login", gin.WrapH(opRouter))
 
 	r.GET("/get_test_token", func(c *gin.Context) {
 		token, err := op.GetToken()

--- a/examples/op/main.go
+++ b/examples/op/main.go
@@ -14,6 +14,7 @@ func main() {
 		optest.WithIssuer("http://localhost:8082"),
 		optest.WithoutAutoStart(),
 		optest.WithDefaultTestUser("test"),
+		optest.WithLoginPrompt(),
 		optest.WithTestUsers(map[string]optest.TestUser{
 			"test": {
 				Audience:           "https://localhost:8081",

--- a/optest/optest.go
+++ b/optest/optest.go
@@ -317,7 +317,11 @@ func (op *OPTest) loginHandler(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	tmpl.Execute(w, data)
+	err = tmpl.Execute(w, data)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 }
 
 func (op *OPTest) tokenHandler(w http.ResponseWriter, r *http.Request) {

--- a/optest/optest_test.go
+++ b/optest/optest_test.go
@@ -215,6 +215,7 @@ func TestE2ELoginPrompt(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
 	defer res.Body.Close()
 
 	for id, user := range testUsers {

--- a/optest/optest_test.go
+++ b/optest/optest_test.go
@@ -184,6 +184,50 @@ func TestE2EOtherUser(t *testing.T) {
 	td.testValidateTokenResponse(t, tr, testUsers[testSecondaryUser])
 }
 
+func TestE2ELoginPrompt(t *testing.T) {
+	op, err := New(WithTestUsers(testUsers), WithDefaultTestUser(testDefaultUser), WithLoginPrompt())
+	require.NoError(t, err)
+	defer op.Close()
+
+	httpClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	td := &testData{
+		baseURL:     op.GetURL(),
+		redirectUrl: "http://foobar.baz/callback",
+		clientID:    "test-client",
+		httpClient:  httpClient,
+	}
+
+	td.testMetadata(t)
+
+	remoteUrl, err := url.Parse(td.metadata.AuthorizationEndpoint)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("GET", remoteUrl.String(), nil)
+	require.NoError(t, err)
+
+	res, err := td.httpClient.Do(req)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	defer res.Body.Close()
+
+	for id, user := range testUsers {
+		require.Contains(t, string(body), fmt.Sprintf("login_hint=%s", id))
+		require.Contains(t, string(body), fmt.Sprintf(">%s</a>", user.Name))
+	}
+
+	td.testAuthorization(t, testDefaultUser)
+	td.testJwks(t)
+	tr := td.testToken(t, testDefaultUser)
+	td.testValidateTokenResponse(t, tr, testUsers[testDefaultUser])
+}
+
 func (td *testData) testAuthorization(t *testing.T, loginHint string) {
 	t.Helper()
 

--- a/optest/options.go
+++ b/optest/options.go
@@ -4,12 +4,13 @@ import "time"
 
 // Options is the configuration object for OPTest.
 type Options struct {
-	Issuer          string
-	DefaultTestUser string
-	TestUsers       map[string]TestUser
-	TokenExpiration time.Duration
-	AutoStart       bool
-	AccessTokenType AccessTokenType
+	Issuer             string
+	DefaultTestUser    string
+	TestUsers          map[string]TestUser
+	TokenExpiration    time.Duration
+	AutoStart          bool
+	AccessTokenType    AccessTokenType
+	LoginPromptEnabled bool
 }
 
 // AccessTokenType defines the type of token to be used.
@@ -70,5 +71,13 @@ func WithoutAutoStart() Option {
 func WithOpaqueAccessTokens() Option {
 	return func(opts *Options) {
 		opts.AccessTokenType = OpaqueAccessTokenType
+	}
+}
+
+// WithLoginPrompt enables login prompt if there are more than one Test User.
+// Default is login prompt disabled.
+func WithLoginPrompt() Option {
+	return func(opts *Options) {
+		opts.LoginPromptEnabled = true
 	}
 }


### PR DESCRIPTION
Fixes #223 

This PR introduces the option `optest.WithLoginPrompt()`. When enabled and you have more than one user, a HTML page will be show at `/authorization` that lets you select what user to login with.