### PR TITLE
Stop using deprecated method in workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Get tag
         id: get_tag
-        run: |
-          echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Set up Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/