### PR TITLE
Add Option to disable issuer validation

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -47,6 +47,7 @@ type Options struct {
 	RequiredTokenType          string
 	RequiredAudience           string
 	DisableKeyID               bool
+	DisableIssuerValidation    bool
 	HttpClient                 *http.Client
 	TokenString                [][]TokenStringOption
 	ClaimsContextKeyName       ClaimsContextKeyName
@@ -250,5 +251,14 @@ func WithClaimsContextKeyName(opt string) Option {
 func WithErrorHandler(opt ErrorHandler) Option {
 	return func(opts *Options) {
 		opts.ErrorHandler = opt
+	}
+}
+
+// WithDisableIssuerValidation will disable the Issuer validation.
+// Use with care, make sure to do some kind of validation inside of the ClaimsValidationFn.
+// Default to false
+func WithDisableIssuerValidation() Option {
+	return func(opts *Options) {
+		opts.DisableIssuerValidation = true
 	}
 }


### PR DESCRIPTION
This patch introduces the option WithDisableIssuerValidation() that stops the issuer validation and leaves it to the library user to do it with the ClaimsValidationFn.