### PR TITLE
Add support for AbortHandler

### DIFF
--- a/oidcfiber/fiber.go
+++ b/oidcfiber/fiber.go
@@ -19,12 +19,17 @@ func New[T any](claimsValidationFn options.ClaimsValidationFn[T], setters ...opt
 	return toFiberHandler(oidcHandler.ParseToken, setters...)
 }
 
-func onError(c *fiber.Ctx, errorHandler options.ErrorHandler, statusCode int, description options.ErrorDescription, err error) error {
-	if errorHandler != nil {
-		errorHandler(description, err)
+func onError(c *fiber.Ctx, o *options.Options, statusCode int, description options.ErrorDescription, err error) error {
+	if o.ErrorHandler != nil {
+		o.ErrorHandler(description, err)
 	}
 
-	return c.SendStatus(statusCode)
+	if o.AbortHandler != nil {
+		o.AbortHandler(c, statusCode, description, err)
+		return err
+	} else {
+		return c.SendStatus(statusCode)
+	}
 }
 
 func toFiberHandler[T any](parseToken oidc.ParseTokenFunc[T], setters ...options.Option) fiber.Handler {
@@ -39,12 +44,12 @@ func toFiberHandler[T any](parseToken oidc.ParseTokenFunc[T], setters ...options
 
 		tokenString, err := oidc.GetTokenString(getHeaderFn, opts.TokenString)
 		if err != nil {
-			return onError(c, opts.ErrorHandler, fiber.StatusBadRequest, options.GetTokenErrorDescription, err)
+			return onError(c, opts, fiber.StatusBadRequest, options.GetTokenErrorDescription, err)
 		}
 
 		claims, err := parseToken(ctx, tokenString)
 		if err != nil {
-			return onError(c, opts.ErrorHandler, fiber.StatusUnauthorized, options.ParseTokenErrorDescription, err)
+			return onError(c, opts, fiber.StatusUnauthorized, options.ParseTokenErrorDescription, err)
 		}
 
 		c.Locals(string(opts.ClaimsContextKeyName), claims)

--- a/options/options.go
+++ b/options/options.go
@@ -21,7 +21,10 @@ const DefaultClaimsContextKeyName ClaimsContextKeyName = "claims"
 // ErrorHandler is called by the middleware if not nil
 type ErrorHandler func(description ErrorDescription, err error)
 
-// ErrorDescription is used to pass the description of the error to ErrorHandler
+// AbortHandler is called by the middleware if not nil
+type AbortHandler func(c interface{}, statusCode int, description ErrorDescription, err error)
+
+// ErrorDescription is used to pass the description of the error to ErrorHandler and AbortHandler
 type ErrorDescription string
 
 const (
@@ -52,6 +55,7 @@ type Options struct {
 	TokenString                [][]TokenStringOption
 	ClaimsContextKeyName       ClaimsContextKeyName
 	ErrorHandler               ErrorHandler
+	AbortHandler               AbortHandler
 }
 
 // New takes Option setters and returns an Options pointer.
@@ -251,6 +255,16 @@ func WithClaimsContextKeyName(opt string) Option {
 func WithErrorHandler(opt ErrorHandler) Option {
 	return func(opts *Options) {
 		opts.ErrorHandler = opt
+	}
+}
+
+// WithAbortHandler sets the AbortHandler parameter for an Options pointer.
+// You can pass a function to control how the middleware should abort
+// handling in case of errors.
+// Defaults to nil
+func WithAbortHandler(opt AbortHandler) Option {
+	return func(opts *Options) {
+		opts.AbortHandler = opt
 	}
 }
 


### PR DESCRIPTION
With this PR, we will have support for `AbortHandler`, which will be responsible for sending a result and aborting the middleware processing. This is to address the current issue where the `Content-Type` of the error response is always `text/plan`.