### PR TITLE
Error handlers are responsible for HTTP response

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,11 +319,24 @@ oidcHandler := oidcgin.New(
 
 ### Custom error handler
 
-It is possible to add a custom function to handle errors. It will not be possible to change anything using it, but you will be able to add logic for logging as an example.
+It is possible to add a custom function to handle errors. The error handler can return an `options.Response` which will be rendered by the middleware. Returning `nil` will result in a default 400/401 error.
 
 ```go
-errorHandler := func(description options.ErrorDescription, err error) {
-	fmt.Printf("Description: %s\tError: %v\n", description, err)
+type Message struct {
+  Message string `json:"message"`
+	Url string `json:"url"`
+}
+
+errorHandler := func(ctx context.Context, request *OidcError) *Response {
+	message := Message {
+		Message: request.status,
+		Url: request.Url,
+	}
+	json, _ := json.Marshal(message)
+	return &options.Response {
+		Status: 418,
+		Body: json,
+	}
 }
 
 oidcHandler := oidcgin.New(

--- a/internal/oidctesting/tests.go
+++ b/internal/oidctesting/tests.go
@@ -321,14 +321,14 @@ func runTestErrorHandler(t *testing.T, testName string, tester tester) {
 		}{
 			{
 				testDescription:    "no output",
-				errorHandler:       func(ctx context.Context, request *options.OidcError) *options.Response { return nil },
+				errorHandler:       func(ctx context.Context, oidcErr *options.OidcError) *options.Response { return nil },
 				expectStatusCode:   http.StatusBadRequest,
 				expectHeaders:      map[string]string{},
 				expectBodyContains: []byte{},
 			},
 			{
 				testDescription: "basic propagation",
-				errorHandler: func(ctx context.Context, request *options.OidcError) *options.Response {
+				errorHandler: func(ctx context.Context, oidcErr *options.OidcError) *options.Response {
 					return &options.Response{
 						StatusCode: 418,
 						Headers:    map[string]string{},
@@ -343,7 +343,7 @@ func runTestErrorHandler(t *testing.T, testName string, tester tester) {
 			},
 			{
 				testDescription: "additional header",
-				errorHandler: func(ctx context.Context, request *options.OidcError) *options.Response {
+				errorHandler: func(ctx context.Context, oidcErr *options.OidcError) *options.Response {
 					return &options.Response{
 						StatusCode: 418,
 						Headers:    map[string]string{"some": "header"},
@@ -359,7 +359,7 @@ func runTestErrorHandler(t *testing.T, testName string, tester tester) {
 			},
 			{
 				testDescription: "content type",
-				errorHandler: func(ctx context.Context, request *options.OidcError) *options.Response {
+				errorHandler: func(ctx context.Context, oidcErr *options.OidcError) *options.Response {
 					return &options.Response{
 						StatusCode: 418,
 						Headers:    map[string]string{"content-type": "application/json"},

--- a/internal/oidctesting/tests.go
+++ b/internal/oidctesting/tests.go
@@ -1,6 +1,7 @@
 package oidctesting
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -320,14 +321,14 @@ func runTestErrorHandler(t *testing.T, testName string, tester tester) {
 		}{
 			{
 				testDescription:    "no output",
-				errorHandler:       func(desc options.ErrorDescription, err error) *options.Response { return nil },
+				errorHandler:       func(ctx context.Context, request *options.OidcError) *options.Response { return nil },
 				expectStatusCode:   http.StatusBadRequest,
 				expectHeaders:      map[string]string{},
 				expectBodyContains: []byte{},
 			},
 			{
 				testDescription: "basic propagation",
-				errorHandler: func(desc options.ErrorDescription, err error) *options.Response {
+				errorHandler: func(ctx context.Context, request *options.OidcError) *options.Response {
 					return &options.Response{
 						StatusCode: 418,
 						Headers:    map[string]string{},
@@ -342,7 +343,7 @@ func runTestErrorHandler(t *testing.T, testName string, tester tester) {
 			},
 			{
 				testDescription: "additional header",
-				errorHandler: func(desc options.ErrorDescription, err error) *options.Response {
+				errorHandler: func(ctx context.Context, request *options.OidcError) *options.Response {
 					return &options.Response{
 						StatusCode: 418,
 						Headers:    map[string]string{"some": "header"},
@@ -358,7 +359,7 @@ func runTestErrorHandler(t *testing.T, testName string, tester tester) {
 			},
 			{
 				testDescription: "content type",
-				errorHandler: func(desc options.ErrorDescription, err error) *options.Response {
+				errorHandler: func(ctx context.Context, request *options.OidcError) *options.Response {
 					return &options.Response{
 						StatusCode: 418,
 						Headers:    map[string]string{"content-type": "application/json"},

--- a/internal/oidctesting/tests.go
+++ b/internal/oidctesting/tests.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -313,65 +311,91 @@ func runTestErrorHandler(t *testing.T, testName string, tester tester) {
 		op := optest.NewTesting(t)
 		defer op.Close(t)
 
-		var info struct {
-			sync.RWMutex
-			description options.ErrorDescription
-			err         error
+		cases := []struct {
+			testDescription    string
+			errorHandler       options.ErrorHandler
+			expectStatusCode   int
+			expectHeaders      map[string]string
+			expectBodyContains []byte
+		}{
+			{
+				testDescription:    "no output",
+				errorHandler:       func(desc options.ErrorDescription, err error) *options.Response { return nil },
+				expectStatusCode:   http.StatusBadRequest,
+				expectHeaders:      map[string]string{},
+				expectBodyContains: []byte{},
+			},
+			{
+				testDescription: "basic propagation",
+				errorHandler: func(desc options.ErrorDescription, err error) *options.Response {
+					return &options.Response{
+						StatusCode: 418,
+						Headers:    map[string]string{},
+						Body:       []byte("badness"),
+					}
+				},
+				expectStatusCode: http.StatusTeapot,
+				expectHeaders: map[string]string{
+					"Content-Type": "application/octet-stream",
+				},
+				expectBodyContains: []byte("bad"),
+			},
+			{
+				testDescription: "additional header",
+				errorHandler: func(desc options.ErrorDescription, err error) *options.Response {
+					return &options.Response{
+						StatusCode: 418,
+						Headers:    map[string]string{"some": "header"},
+						Body:       []byte("badness"),
+					}
+				},
+				expectStatusCode: http.StatusTeapot,
+				expectHeaders: map[string]string{
+					"Some":         "header",
+					"Content-Type": "application/octet-stream",
+				},
+				expectBodyContains: []byte{},
+			},
+			{
+				testDescription: "content type",
+				errorHandler: func(desc options.ErrorDescription, err error) *options.Response {
+					return &options.Response{
+						StatusCode: 418,
+						Headers:    map[string]string{"content-type": "application/json"},
+						Body:       []byte("{}"),
+					}
+				},
+				expectStatusCode: http.StatusTeapot,
+				expectHeaders: map[string]string{
+					"Content-Type": "application/json",
+				},
+				expectBodyContains: []byte("{}"),
+			},
 		}
+		for i := range cases {
+			c := cases[i]
+			t.Logf("Test iteration %d: %s", i, c.testDescription)
+			opts := []options.Option{
+				options.WithIssuer(op.GetURL(t)),
+				options.WithRequiredAudience("test-client"),
+				options.WithRequiredTokenType("JWT+AT"),
+				options.WithErrorHandler(c.errorHandler),
+			}
 
-		setInfo := func(description options.ErrorDescription, err error) {
-			info.Lock()
-			info.description = description
-			info.err = err
-			info.Unlock()
+			oidcHandler, err := oidc.NewHandler[TestClaims](nil, opts...)
+			require.NoError(t, err)
+
+			handler := tester.ToHandlerFn(oidcHandler.ParseToken, opts...)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			res := httptest.NewRecorder()
+			handler.ServeHTTP(res, req)
+			require.Equal(t, c.expectStatusCode, res.Result().StatusCode)
+			for k, v := range c.expectHeaders {
+				require.Equal(t, []string{v}, res.Result().Header[k])
+			}
+			require.Subset(t, res.Body.Bytes(), c.expectBodyContains)
 		}
-
-		getInfo := func() (description options.ErrorDescription, err error) {
-			info.RLock()
-			defer info.RUnlock()
-			return info.description, info.err
-		}
-
-		errorHandler := func(description options.ErrorDescription, err error) {
-			t.Logf("Description: %s\tError: %v", description, err)
-			setInfo(description, err)
-		}
-
-		opts := []options.Option{
-			options.WithIssuer(op.GetURL(t)),
-			options.WithRequiredAudience("test-client"),
-			options.WithRequiredTokenType("JWT+AT"),
-			options.WithErrorHandler(errorHandler),
-		}
-
-		oidcHandler, err := oidc.NewHandler[TestClaims](nil, opts...)
-		require.NoError(t, err)
-
-		handler := tester.ToHandlerFn(oidcHandler.ParseToken, opts...)
-
-		// Test without token
-		reqNoAuth := httptest.NewRequest(http.MethodGet, "/", nil)
-		recNoAuth := httptest.NewRecorder()
-		handler.ServeHTTP(recNoAuth, reqNoAuth)
-
-		require.Equal(t, http.StatusBadRequest, recNoAuth.Result().StatusCode)
-
-		d, e := getInfo()
-
-		if !strings.Contains(t.Name(), "OidcEchoJwt") {
-			require.Equal(t, options.GetTokenErrorDescription, d)
-			require.EqualError(t, e, "unable to extract token: Authorization header empty")
-		}
-
-		// Test with fake token
-		token := op.GetToken(t)
-		token.AccessToken = "foobar"
-		testHttpWithAuthenticationFailure(t, token, handler)
-
-		d, e = getInfo()
-
-		require.Equal(t, options.ParseTokenErrorDescription, d)
-		require.EqualError(t, e, "unable to parse token signature: invalid compact serialization format: invalid number of segments")
 	})
 }
 

--- a/oidcecho/echo.go
+++ b/oidcecho/echo.go
@@ -19,10 +19,23 @@ func New[T any](claimsValidationFn options.ClaimsValidationFn[T], setters ...opt
 	return toEchoMiddleware(h.ParseToken, setters...)
 }
 
-func onError(errorHandler options.ErrorHandler, description options.ErrorDescription, err error) {
-	if errorHandler != nil {
-		errorHandler(description, err)
+func onError(c echo.Context, errorHandler options.ErrorHandler, statusCode int, description options.ErrorDescription, err error) error {
+	if errorHandler == nil {
+		c.Logger().Error(err)
+		return c.NoContent(statusCode)
 	}
+	response := errorHandler(description, err)
+	if response == nil {
+		c.Logger().Error(err)
+		return c.NoContent(statusCode)
+	}
+	for k, v := range response.Headers {
+		c.Response().Header().Set(k, v)
+	}
+	c.Response().Header().Set(echo.HeaderContentType, response.ContentType())
+	c.Response().WriteHeader(response.StatusCode)
+	_, err = c.Response().Write(response.Body)
+	return err
 }
 
 func toEchoMiddleware[T any](parseToken oidc.ParseTokenFunc[T], setters ...options.Option) echo.MiddlewareFunc {
@@ -34,14 +47,12 @@ func toEchoMiddleware[T any](parseToken oidc.ParseTokenFunc[T], setters ...optio
 
 			tokenString, err := oidc.GetTokenString(c.Request().Header.Get, opts.TokenString)
 			if err != nil {
-				onError(opts.ErrorHandler, options.GetTokenErrorDescription, err)
-				return echo.ErrBadRequest
+				return onError(c, opts.ErrorHandler, echo.ErrBadRequest.Code, options.GetTokenErrorDescription, err)
 			}
 
 			claims, err := parseToken(ctx, tokenString)
 			if err != nil {
-				onError(opts.ErrorHandler, options.ParseTokenErrorDescription, err)
-				return echo.ErrUnauthorized
+				return onError(c, opts.ErrorHandler, echo.ErrUnauthorized.Code, options.ParseTokenErrorDescription, err)
 			}
 			c.Set(string(opts.ClaimsContextKeyName), claims)
 			return next(c)

--- a/oidcecho/echo.go
+++ b/oidcecho/echo.go
@@ -24,7 +24,13 @@ func onError(c echo.Context, errorHandler options.ErrorHandler, statusCode int, 
 		c.Logger().Error(err)
 		return c.NoContent(statusCode)
 	}
-	response := errorHandler(description, err)
+	error := options.OidcError{
+		Url:     c.Request().URL,
+		Headers: c.Request().Header,
+		Status:  description,
+		Error:   err,
+	}
+	response := errorHandler(c.Request().Context(), &error)
 	if response == nil {
 		c.Logger().Error(err)
 		return c.NoContent(statusCode)

--- a/oidcecho/echo.go
+++ b/oidcecho/echo.go
@@ -24,13 +24,13 @@ func onError(c echo.Context, errorHandler options.ErrorHandler, statusCode int, 
 		c.Logger().Error(err)
 		return c.NoContent(statusCode)
 	}
-	error := options.OidcError{
+	oidcErr := options.OidcError{
 		Url:     c.Request().URL,
 		Headers: c.Request().Header,
 		Status:  description,
 		Error:   err,
 	}
-	response := errorHandler(c.Request().Context(), &error)
+	response := errorHandler(c.Request().Context(), &oidcErr)
 	if response == nil {
 		c.Logger().Error(err)
 		return c.NoContent(statusCode)

--- a/oidcfiber/fiber.go
+++ b/oidcfiber/fiber.go
@@ -29,13 +29,13 @@ func onError(c *fiber.Ctx, errorHandler options.ErrorHandler, statusCode int, de
 	for k, v := range c.GetReqHeaders() {
 		headers[k] = []string{v}
 	}
-	error := options.OidcError{
+	oidcErr := options.OidcError{
 		Url:     url,
 		Headers: headers,
 		Status:  description,
 		Error:   err,
 	}
-	response := errorHandler(c.Context(), &error)
+	response := errorHandler(c.Context(), &oidcErr)
 	if response == nil {
 		return c.SendStatus(statusCode)
 	}

--- a/oidcfiber/fiber.go
+++ b/oidcfiber/fiber.go
@@ -2,6 +2,7 @@ package oidcfiber
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/xenitab/go-oidc-middleware/internal/oidc"
@@ -23,7 +24,18 @@ func onError(c *fiber.Ctx, errorHandler options.ErrorHandler, statusCode int, de
 	if errorHandler == nil {
 		return c.SendStatus(statusCode)
 	}
-	response := errorHandler(description, err)
+	url, _ := url.Parse(c.OriginalURL())
+	headers := make(map[string][]string, 1)
+	for k, v := range c.GetReqHeaders() {
+		headers[k] = []string{v}
+	}
+	error := options.OidcError{
+		Url:     url,
+		Headers: headers,
+		Status:  description,
+		Error:   err,
+	}
+	response := errorHandler(c.Context(), &error)
 	if response == nil {
 		return c.SendStatus(statusCode)
 	}

--- a/oidcfiber/fiber.go
+++ b/oidcfiber/fiber.go
@@ -20,11 +20,18 @@ func New[T any](claimsValidationFn options.ClaimsValidationFn[T], setters ...opt
 }
 
 func onError(c *fiber.Ctx, errorHandler options.ErrorHandler, statusCode int, description options.ErrorDescription, err error) error {
-	if errorHandler != nil {
-		errorHandler(description, err)
+	if errorHandler == nil {
+		return c.SendStatus(statusCode)
 	}
-
-	return c.SendStatus(statusCode)
+	response := errorHandler(description, err)
+	if response == nil {
+		return c.SendStatus(statusCode)
+	}
+	for k, v := range response.Headers {
+		c.Response().Header.Set(k, v)
+	}
+	c.Set("Content-Type", response.ContentType())
+	return c.Status(response.StatusCode).Send(response.Body)
 }
 
 func toFiberHandler[T any](parseToken oidc.ParseTokenFunc[T], setters ...options.Option) fiber.Handler {

--- a/oidcgin/gin.go
+++ b/oidcgin/gin.go
@@ -25,13 +25,13 @@ func onError(c *gin.Context, errorHandler options.ErrorHandler, statusCode int, 
 		return c.AbortWithError(statusCode, err)
 	}
 
-	error := options.OidcError{
+	oidcErr := options.OidcError{
 		Url:     c.Request.URL,
 		Headers: c.Request.Header,
 		Status:  description,
 		Error:   err,
 	}
-	response := errorHandler(c.Request.Context(), &error)
+	response := errorHandler(c.Request.Context(), &oidcErr)
 	if response == nil {
 		return c.AbortWithError(statusCode, err)
 	}

--- a/oidcgin/gin.go
+++ b/oidcgin/gin.go
@@ -24,7 +24,14 @@ func onError(c *gin.Context, errorHandler options.ErrorHandler, statusCode int, 
 	if errorHandler == nil {
 		return c.AbortWithError(statusCode, err)
 	}
-	response := errorHandler(description, err)
+
+	error := options.OidcError{
+		Url:     c.Request.URL,
+		Headers: c.Request.Header,
+		Status:  description,
+		Error:   err,
+	}
+	response := errorHandler(c.Request.Context(), &error)
 	if response == nil {
 		return c.AbortWithError(statusCode, err)
 	}

--- a/oidchttp/http.go
+++ b/oidchttp/http.go
@@ -25,13 +25,13 @@ func onError(r *http.Request, w http.ResponseWriter, errorHandler options.ErrorH
 		w.WriteHeader(statusCode)
 		return
 	}
-	error := options.OidcError{
+	oidcErr := options.OidcError{
 		Url:     r.URL,
 		Headers: r.Header,
 		Status:  description,
 		Error:   err,
 	}
-	response := errorHandler(r.Context(), &error)
+	response := errorHandler(r.Context(), &oidcErr)
 	if response == nil {
 		w.WriteHeader(statusCode)
 		return

--- a/oidchttp/http.go
+++ b/oidchttp/http.go
@@ -21,11 +21,21 @@ func New[T any](h http.Handler, claimsValidationFn options.ClaimsValidationFn[T]
 }
 
 func onError(w http.ResponseWriter, errorHandler options.ErrorHandler, statusCode int, description options.ErrorDescription, err error) {
-	if errorHandler != nil {
-		errorHandler(description, err)
+	if errorHandler == nil {
+		w.WriteHeader(statusCode)
+		return
 	}
-
-	w.WriteHeader(statusCode)
+	response := errorHandler(description, err)
+	if response == nil {
+		w.WriteHeader(statusCode)
+		return
+	}
+	for k, v := range response.Headers {
+		w.Header().Add(k, v)
+	}
+	w.Header().Set("Content-Type", response.ContentType())
+	w.WriteHeader(response.StatusCode)
+	w.Write(response.Body)
 }
 
 func toHttpHandler[T any](h http.Handler, parseToken oidc.ParseTokenFunc[T], setters ...options.Option) http.Handler {

--- a/options/options.go
+++ b/options/options.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// Context information for the error handler.
+// OidcError contains context information for the error handler.
 type OidcError struct {
 	Url     *url.URL
 	Headers http.Header
@@ -15,15 +15,14 @@ type OidcError struct {
 	Status  ErrorDescription
 }
 
-// Error handlers are expected to produce an abstract HTTP response that
-// the framework adapter will render.
+// Response holds an abstract HTTP response that the framework adapter will render.
 type Response struct {
 	StatusCode int
 	Headers    map[string]string
 	Body       []byte
 }
 
-// Return the content-type header from this response, or "applicatin/octet-stream"
+// ContentType returns the content-type header from this response, or "applicatin/octet-stream"
 // as per HTTP standard.
 func (r *Response) ContentType() string {
 	for k, v := range r.Headers {
@@ -48,7 +47,7 @@ type ClaimsContextKeyName string
 const DefaultClaimsContextKeyName ClaimsContextKeyName = "claims"
 
 // ErrorHandler is called by the middleware if not nil
-type ErrorHandler func(ctx context.Context, request *OidcError) *Response
+type ErrorHandler func(ctx context.Context, oidcErr *OidcError) *Response
 
 // ErrorDescription is used to pass the description of the error to ErrorHandler
 type ErrorDescription string

--- a/options/options.go
+++ b/options/options.go
@@ -5,6 +5,23 @@ import (
 	"time"
 )
 
+type Response struct {
+	StatusCode int
+	Headers    map[string]string
+	Body       []byte
+}
+
+// Return the content-type header from this response, or "applicatin/octet-stream"
+// as per HTTP standard.
+func (r *Response) ContentType() string {
+	for k, v := range r.Headers {
+		if http.CanonicalHeaderKey(k) == "Content-Type" {
+			return v
+		}
+	}
+	return "application/octet-stream"
+}
+
 // ClaimsValidationFn is a generic function to validate calims.
 // If an error is returned, the claims failed the validation.
 // If `nil` is provided instead of a function when configuration the handler,
@@ -19,7 +36,7 @@ type ClaimsContextKeyName string
 const DefaultClaimsContextKeyName ClaimsContextKeyName = "claims"
 
 // ErrorHandler is called by the middleware if not nil
-type ErrorHandler func(description ErrorDescription, err error)
+type ErrorHandler func(description ErrorDescription, err error) *Response
 
 // ErrorDescription is used to pass the description of the error to ErrorHandler
 type ErrorDescription string

--- a/options/options.go
+++ b/options/options.go
@@ -1,10 +1,22 @@
 package options
 
 import (
+	"context"
 	"net/http"
+	"net/url"
 	"time"
 )
 
+// Context information for the error handler.
+type OidcError struct {
+	Url     *url.URL
+	Headers http.Header
+	Error   error
+	Status  ErrorDescription
+}
+
+// Error handlers are expected to produce an abstract HTTP response that
+// the framework adapter will render.
 type Response struct {
 	StatusCode int
 	Headers    map[string]string
@@ -36,7 +48,7 @@ type ClaimsContextKeyName string
 const DefaultClaimsContextKeyName ClaimsContextKeyName = "claims"
 
 // ErrorHandler is called by the middleware if not nil
-type ErrorHandler func(description ErrorDescription, err error) *Response
+type ErrorHandler func(ctx context.Context, request *OidcError) *Response
 
 // ErrorDescription is used to pass the description of the error to ErrorHandler
 type ErrorDescription string


### PR DESCRIPTION
Allow error handlers to return an abstract HTTP response which the framework is then responsible for rendering. This allows users to return e.g. structured and localized responses from the middleware.

This is a breaking change in that existing error handlers need a signature change and `return nil` to retain existing behavior.

This is an alternative to #251 as discussed in that PR. Fixes #249 .